### PR TITLE
Feature/replace deprecated async

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -12,13 +12,13 @@ import { ProfileModule } from './profile/profile.module';
 import { HighscoresModule } from './highscores/highscores.module';
 
 describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [LoaderModule, MaterialModule, RouterTestingModule, TranslateModule.forRoot(), ProfileModule, HighscoresModule],
       declarations: [AppComponent, FooterComponent, HeaderComponent],
       providers: [{ provide: AuthService, useClass: MockAuthService }]
     }).compileComponents();
-  }));
+  });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/src/app/core/components/community-guidelines/community-guidelines.component.spec.ts
+++ b/src/app/core/components/community-guidelines/community-guidelines.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CommunityGuidelinesComponent } from './community-guidelines.component';
 
@@ -6,12 +6,12 @@ describe('CommunityGuidelinesComponent', () => {
   let component: CommunityGuidelinesComponent;
   let fixture: ComponentFixture<CommunityGuidelinesComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [ CommunityGuidelinesComponent ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CommunityGuidelinesComponent);

--- a/src/app/core/components/header/header.component.spec.ts
+++ b/src/app/core/components/header/header.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {HeaderComponent} from './header.component';
 import {RouterTestingModule} from '@angular/router/testing';
@@ -13,8 +13,8 @@ describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
         MaterialModule,
@@ -27,7 +27,7 @@ describe('HeaderComponent', () => {
       ]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeaderComponent);

--- a/src/app/core/dialogs/delete-user-dialog/delete-user-dialog.component.spec.ts
+++ b/src/app/core/dialogs/delete-user-dialog/delete-user-dialog.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {DeleteUserDialogComponent} from './delete-user-dialog.component';
 import {MatDialogRef} from '@angular/material/dialog';
@@ -12,8 +12,8 @@ describe('DeleteUserDialogComponent', () => {
   let component: DeleteUserDialogComponent;
   let fixture: ComponentFixture<DeleteUserDialogComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MaterialModule
       ],
@@ -25,7 +25,7 @@ describe('DeleteUserDialogComponent', () => {
       ]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DeleteUserDialogComponent);

--- a/src/app/core/dialogs/report-item-dialog/report-item-dialog.component.html
+++ b/src/app/core/dialogs/report-item-dialog/report-item-dialog.component.html
@@ -5,7 +5,7 @@
   </div>
   <div class="message">
     <div class="message__intro">Erkläre uns hier kurz, warum du den {{ type }} meldest</div>
-    <textarea class="textarea" rows="5" [(ngModel)]="data.message" name="message" aria-label="message" required></textarea>
+    <textarea class="textarea" rows="5" [(ngModel)]="data.message" placeholder="Inhalt eingeben" onclick="this.placeholder=''" name="message" aria-label="message" required></textarea>
   </div>
   <div class="buttons">
     <button appButton mode="reject" (click)="close()">Abbrechen</button>

--- a/src/app/core/dialogs/report-item-dialog/report-item-dialog.component.scss
+++ b/src/app/core/dialogs/report-item-dialog/report-item-dialog.component.scss
@@ -12,7 +12,7 @@ h1 {
 
   @include fonts.font__pt-mono--regular;
   font-size: 14px;
-  color: colors.$color__old-paragraph;
+  color: colors.$color__purple;
   margin: 0 0 30px;
   padding: 15px 5px 15px 15px;
   border-radius: 30px;
@@ -37,11 +37,16 @@ h1 {
     padding: 15px;
     margin-top: 12px;
     font-size: 18px;
-    resize: vertical;
+    resize: vertical;    
+
+    &:hover {
+      background-color: rgba($color: colors.$color__user-input-border, $alpha: 0.1);
+    }
 
     &:focus {
-      border: 1px solid grey;
+      border: 2px solid colors.$color__user_input_border;
     }
+
   }
 }
 

--- a/src/app/home/components/home/home.component.spec.ts
+++ b/src/app/home/components/home/home.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { OpenCaseListSliderModule } from '@shared/open-case-list-slider/open-case-list-slider.module';
@@ -9,13 +9,13 @@ describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [RouterTestingModule, OpenCaseListSliderModule],
       declarations: [HomeComponent],
       providers: [{ provide: AuthService, useClass: MockAuthService }]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HomeComponent);

--- a/src/app/issues/components/issues/issues.component.html
+++ b/src/app/issues/components/issues/issues.component.html
@@ -21,7 +21,7 @@
         <mat-form-field>
           <mat-label>Erkläre uns möglichst genau, worum es dir geht.
           </mat-label>
-          <textarea formControlName="messageFormControl" matInput rows="20"></textarea>
+          <textarea formControlName="messageFormControl" matInput rows="20" placeholder="Nachricht eingeben"></textarea>
           <mat-error>Bitte gib eine Nachricht ein</mat-error>
         </mat-form-field>
         <mat-checkbox class="checkbox" formControlName="checkboxFormControl" tabindex="-1" autocomplete="off">

--- a/src/app/my-profile/components/my-profile/my-profile.component.spec.ts
+++ b/src/app/my-profile/components/my-profile/my-profile.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MyProfileComponent } from './my-profile.component';
 import { MaterialModule } from '@shared/material/material.module';
@@ -18,12 +18,7 @@ import { ArchiveState } from '../../../archive/state/archive.state';
 import { ArchiveService } from '../../../archive/services/archive.service';
 import { MockArchiveService } from '@mocks/mock-archive.service';
 import { BreadcrumbModule } from '@shared/breadcrumb/breadcrumb.module';
-import { PipesModule } from '@shared/pipes/pipes.module';
 import { LeadingZerosPipe } from '../../pipes/leading-zeros.pipe';
-import { UserXpBarComponent } from '@shared/user-xp/user-xp-bar/user-xp-bar.component';
-import { UserXpScoreComponent } from '@shared/user-xp/user-xp-score/user-xp-score.component';
-import { CaseListItemComponent } from '@shared/case-list-item/case-list-item/case-list-item.component';
-import { SolvedCasesComponent } from '@shared/solved-cases/solved-cases/solved-cases.component';
 import { SolvedCasesModule } from '@shared/solved-cases/solved-cases.module';
 import { CaseListItemModule } from '@shared/case-list-item/case-list-item.module';
 import { UserXpModule } from '@shared/user-xp/user-xp.module';
@@ -32,8 +27,8 @@ describe('MyProfileComponent', () => {
   let component: MyProfileComponent;
   let fixture: ComponentFixture<MyProfileComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [MyProfileComponent, ScoreListComponent, SolveScoreListComponent, ScoreListItemComponent, LeadingZerosPipe],
       imports: [
         MaterialModule,
@@ -53,7 +48,7 @@ describe('MyProfileComponent', () => {
         { provide: ArchiveService, useClass: MockArchiveService }
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyProfileComponent);

--- a/src/app/profile/components/profile/profile.component.spec.ts
+++ b/src/app/profile/components/profile/profile.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProfileComponent } from './profile.component';
 import { MaterialModule } from '@shared/material/material.module';
@@ -14,8 +14,8 @@ describe('ProfileComponent', () => {
   let component: ProfileComponent;
   let fixture: ComponentFixture<ProfileComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [ProfileComponent, ProfilePictureComponent],
       imports: [MaterialModule, RouterTestingModule, FormsModule],
       providers: [
@@ -23,7 +23,7 @@ describe('ProfileComponent', () => {
         { provide: UserService, useClass: MockUserService },
       ],
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProfileComponent);

--- a/src/app/review-item/components/tags-question/tags-question.component.spec.ts
+++ b/src/app/review-item/components/tags-question/tags-question.component.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { UserService } from '../../../core/services/user/user.service';
 import { AuthService } from '@shared/auth/auth-service/auth.service';
@@ -16,8 +16,8 @@ describe('TagsQuestionComponent', () => {
   let component: TagsQuestionComponent;
   let fixture: ComponentFixture<TagsQuestionComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [TagsQuestionComponent],
       imports: [RouterTestingModule, MaterialModule, LoaderModule, CommonModule, HelperModule, UnsavedChangesModule],
       providers: [
@@ -25,7 +25,7 @@ describe('TagsQuestionComponent', () => {
         { provide: UserService, useClass: MockUserService }
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TagsQuestionComponent);

--- a/src/app/shared/auth/dialogs/confirm/confirm.component.spec.ts
+++ b/src/app/shared/auth/dialogs/confirm/confirm.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ConfirmComponent } from './confirm.component';
 import {AuthService} from '../../auth-service/auth.service';
@@ -10,8 +10,8 @@ describe('ConfirmComponent', () => {
   let component: ConfirmComponent;
   let fixture: ComponentFixture<ConfirmComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MaterialModule
       ],
@@ -23,7 +23,7 @@ describe('ConfirmComponent', () => {
       ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfirmComponent);

--- a/src/app/shared/auth/dialogs/forgot-password-submit/forgot-password-submit.component.spec.ts
+++ b/src/app/shared/auth/dialogs/forgot-password-submit/forgot-password-submit.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {ForgotPasswordSubmitComponent} from './forgot-password-submit.component';
 import {AuthService} from '../../auth-service/auth.service';
@@ -10,8 +10,8 @@ describe('ForgotPasswordSubmitComponent', () => {
   let component: ForgotPasswordSubmitComponent;
   let fixture: ComponentFixture<ForgotPasswordSubmitComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MaterialModule
       ],
@@ -29,7 +29,7 @@ describe('ForgotPasswordSubmitComponent', () => {
       ]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ForgotPasswordSubmitComponent);

--- a/src/app/shared/auth/dialogs/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/shared/auth/dialogs/forgot-password/forgot-password.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
 import {AuthService} from '../../auth-service/auth.service';
@@ -10,8 +10,8 @@ describe('ForgotPasswordComponent', () => {
   let component: ForgotPasswordComponent;
   let fixture: ComponentFixture<ForgotPasswordComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MaterialModule
       ],
@@ -23,7 +23,7 @@ describe('ForgotPasswordComponent', () => {
       ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ForgotPasswordComponent);

--- a/src/app/shared/auth/dialogs/login/login.component.spec.ts
+++ b/src/app/shared/auth/dialogs/login/login.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LoginComponent } from './login.component';
 import {AuthService} from '../../auth-service/auth.service';
@@ -10,8 +10,8 @@ describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MaterialModule,
       ],
@@ -22,7 +22,7 @@ describe('LoginComponent', () => {
       ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginComponent);

--- a/src/app/shared/auth/dialogs/signup/signup.component.spec.ts
+++ b/src/app/shared/auth/dialogs/signup/signup.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SignupComponent } from './signup.component';
 import {AuthService} from '../../auth-service/auth.service';
@@ -10,8 +10,8 @@ describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MaterialModule,
       ],
@@ -22,7 +22,7 @@ describe('SignupComponent', () => {
       ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SignupComponent);

--- a/src/app/shared/comment-input/comment-input/comment-input.component.html
+++ b/src/app/shared/comment-input/comment-input/comment-input.component.html
@@ -5,10 +5,10 @@
   <div class="reply-body">
     <div *ngIf="user?.name" class="name font-bold">{{ user?.name || 'unbekannt' }}</div>
     <div class="input-container">
-      <textarea [(ngModel)]="comment" (blur)="commentChanged()" rows="5"></textarea>
+      <textarea [(ngModel)]="comment" (blur)="commentChanged()" rows="5" placeholder="Beitrag eingeben" onfocus="this.placeholder=''" onblur="this.placeholder='Beitrag eingeben'"></textarea>
     </div>
     <div class="reply-button-container" *ngIf="!instantChanges">
-      <button (click)="submitComment()" [disabled]="!comment?.length">Posten</button>
+      <button (click)="submitComment()" [disabled]="!comment?.length">Senden</button>
     </div>
   </div>
 </div>

--- a/src/app/shared/comment-input/comment-input/comment-input.component.scss
+++ b/src/app/shared/comment-input/comment-input/comment-input.component.scss
@@ -22,9 +22,13 @@
       padding: 16px;
       resize: vertical;
       font-size: 16px;
+      
+      &:hover {
+        background-color: rgba($color: colors.$color__user-input-border, $alpha: 0.1);
+      }
 
       &:focus {
-        border: 1px solid;
+        border: 2px solid colors.$color__user_input_border;
       }
     }
 

--- a/src/app/shared/helper/components/file/file.component.spec.ts
+++ b/src/app/shared/helper/components/file/file.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FileComponent } from './file.component';
 
@@ -6,12 +6,12 @@ describe('FileComponent', () => {
   let component: FileComponent;
   let fixture: ComponentFixture<FileComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [ FileComponent ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FileComponent);

--- a/src/app/shared/loader/component/loader.component.spec.ts
+++ b/src/app/shared/loader/component/loader.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {LoaderComponent} from './loader.component';
 import {LoaderService} from '../service/loader.service';
@@ -8,15 +8,15 @@ describe('LoaderComponent', () => {
   let component: LoaderComponent;
   let fixture: ComponentFixture<LoaderComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [LoaderComponent],
       providers: [LoaderService],
       imports: [
         MaterialModule
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoaderComponent);

--- a/src/app/shared/unsaved-changes/component/unsaved-changes/unsaved-changes.component.spec.ts
+++ b/src/app/shared/unsaved-changes/component/unsaved-changes/unsaved-changes.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { UnsavedChangesComponent } from './unsaved-changes.component';
 
@@ -6,12 +6,12 @@ describe('UnsavedChangesComponent', () => {
   let component: UnsavedChangesComponent;
   let fixture: ComponentFixture<UnsavedChangesComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [ UnsavedChangesComponent ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UnsavedChangesComponent);

--- a/src/app/static-pages/landing-page/sections/about-section/about-section.component.scss
+++ b/src/app/static-pages/landing-page/sections/about-section/about-section.component.scss
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 40px;
   margin: 20px auto;
   width: max-content;
 

--- a/src/app/submit-item/components/submit-page/submit-page.component.html
+++ b/src/app/submit-item/components/submit-page/submit-page.component.html
@@ -9,7 +9,7 @@
           <div>
             <p>
               Wenn es etwas gibt, was du gerne prüfen lassen möchtest, kannst Du es hier einreichen. 
-              Wenn dieser Fall bereits von unserer Detektiv-Community gelöst wurde, erhältst du sofort das Ergebnis in Form des codetekt Vertrauens-Index.
+              Wenn die Detektiv-Community diesen Fall bereits gelöst hat, erhältst du sofort das Ergebnis in Form des codetekt Vertrauens-Index.
               Andernfalls übergeben wir den Fall direkt an unsere Detektiv*innen.
             </p>
           </div>
@@ -31,8 +31,8 @@
           </p>
           <div class="field-container">
             <p>Um welchen Medien-Typ geht es?*</p>
-            <mat-form-field class="form-select responsive-100">
-              <mat-select [(ngModel)]="form.item_type_id" name="item_type_id" title="Medientyp" required panelClass="test-panel">
+            <mat-form-field class="form-select responsive-100" appearance="outline">             
+              <mat-select [(ngModel)]="form.item_type_id" name="item_type_id" placeholder="Hier wählen" title="Medientyp" required>               
                 <mat-option *ngFor="let itemType of itemTypes$ | async" [value]="itemType.id">
                   {{ itemType.id | itemType }}
                 </mat-option>
@@ -40,13 +40,16 @@
             </mat-form-field>
           </div>
           <div class="field-container">
+            <p *ngIf="form.item_type_id === null">
+              Bitte gib hier <span class="display-item-type">einen Link/ Textnachricht oder Aussage</span> ein*
+            </p>
             <p *ngIf="form.item_type_id === '1' ">
             Bitte gib hier <span class="display-item-type">den {{ form.item_type_id | itemType }}</span> ein*
             </p>
             <p *ngIf="form.item_type_id === '2' ">
               Bitte gib hier <span class="display-item-type">eine {{ form.item_type_id | itemType }}</span> ein*
             </p>
-            <textarea class="textarea" rows="5" [(ngModel)]="form.content" name="content" required></textarea>
+            <textarea class="textarea" [(ngModel)]="form.content" rows="5" placeholder="Hier Inhalt eingeben" onfocus="this.placeholder=''" onblur="this.placeholder='Hier Inhalt eingeben'" name="content" required></textarea>
           </div>
           <div class="lady-detective-svg-container">
             <img src="assets/images/illustrations/lady-detective.svg" />

--- a/src/app/submit-item/components/submit-page/submit-page.component.scss
+++ b/src/app/submit-item/components/submit-page/submit-page.component.scss
@@ -43,6 +43,7 @@
     @media only screen and (min-width: 1024px) {
       margin-left: calc((100vw - 600px) / 3.4); //  ~ 1/3 of extra space
       width: 1200px;
+      padding: 20px 0 20px 40px;
     }
     @media only screen and (min-width: 1350px) {
       margin-left: calc((100vw - 767px) / 3.4); //  ~ 1/3 of extra space
@@ -97,40 +98,66 @@
       .form-select {
         width: 85%;
         font-size: 16px;
-
-        @media only screen and (min-width: 480px) {      
+        margin-top: 10px;
+        @media only screen and (min-width: 480px) {
           width: 41%;
-        } 
+        }
+      }
 
-        .mat-form-field-underline {
-          background-color: $color__user_input_border !important;
-          transform: scaleY(1.4);
+      .mat-form-field:not(.mat-form-field-has-label) .mat-form-field-infix {
+        border-top-width: 0;        
+      }
+
+      .mat-select-placeholder {
+        font-size: 16px;
+        line-height: 18px;
+        font-weight: 400;
+        color: $color__placeholder;
+        transition: none;
+      }
+
+      .mat-form-field-outline {
+        .mat-form-field-outline-start {
+          min-width: 10px;
+          color: $color__select-border;
+          border-radius: 10px 0 0 10px;
+          border-width: 2px 2px 2px 2px;
         }
 
-        .mat-form-field-ripple {
-          background-color: $color__user_input_border;
-          transform: scaleY(0.5);
+        .mat-form-field-outline-end {
+          color: $color__select-border;
+          border-radius: 0 10px 10px 0;
+          border-width: 2px 2px 2px 2px;
         }
+      }
 
-        .mat-select-arrow {
-          color: $color__user_input_border;
+      .mat-form-field-outline-thick {
+        .mat-form-field-outline-start {
+          min-width: 10px;
+          background-color: rgba($color: $color__user-input-border, $alpha: 0.1);
+          color: $color__select-border;
+          border-radius: 10px 0 0 10px;
+          border-width: 2px 2px 2px 2px;
         }
-
-        .mat-select-min-line {
-          color: $color__purple_gradient;
+        .mat-form-field-outline-end {
+          background-color: rgba($color: $color__user-input-border, $alpha: 0.1);
+          color: $color__select-border;
+          border-radius: 0 10px 10px 0;
+          border-width: 2px 2px 2px 2px;
         }
       }    
   
       .textarea {
         width: 100%;
-        border-radius: 10px;
-        padding: 15px;
         margin-top: 10px;
-        font-size: 16px;
+        padding: 15px;
+        $color: $color__select-border;
+        border-radius: 10px;
+        border-width: 2.5px 2px 2px 2.5px;
 
-        border: 2px solid $color__user_input_border;
-        border-top-width: 5px;
-        border-left-width: 5px;
+        &:hover {
+          background-color: rgba($color: $color__user-input-border, $alpha: 0.1);
+        }
 
         &:focus {
           border: 2px solid $color__user_input_border;

--- a/src/app/submit-item/components/submit-page/submit-page.component.ts
+++ b/src/app/submit-item/components/submit-page/submit-page.component.ts
@@ -54,7 +54,7 @@ export class SubmitPageComponent {
   ];
 
   form: SubmitFormData = {
-    item_type_id: '1',
+    item_type_id: null,
     content: null,
     source: null,
     other_source: null,

--- a/src/app/submit-item/components/submit/submit.component.spec.ts
+++ b/src/app/submit-item/components/submit/submit.component.spec.ts
@@ -1,10 +1,9 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SubmitComponent } from './submit.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { SubmitItemService } from '../../services/submit-item.service';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { LoaderModule } from '@shared/loader/loader.module';
 import { MaterialModule } from '@shared/material/material.module';
 import { HelperModule } from '@shared/helper/helper.module';
@@ -14,8 +13,8 @@ describe('SubmitComponent', () => {
   let component: SubmitComponent;
   let fixture: ComponentFixture<SubmitComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
         MaterialModule,
@@ -26,7 +25,7 @@ describe('SubmitComponent', () => {
       declarations: [SubmitComponent],
       providers: [FormBuilder, SubmitItemService],
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SubmitComponent);

--- a/src/assets/scss/_colors.scss
+++ b/src/assets/scss/_colors.scss
@@ -25,6 +25,7 @@ $color__spacer: #cecece;
 $color__old-paragraph: #8989a2;
 $color__accordion-border: #f4f7f6;
 $color__user_input_border: #765dab;
+$color__placeholder: #acacac;
 
 $color__rating-red: #d10e00;
 $color__rating-orange: #ffa700;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -38,6 +38,40 @@
   background: $color__scrollbar-thumb-background-hover;
 }
 
+/* placeholder */
+
+textarea::-webkit-input-placeholder {   /* WebKit, Blink, Edge */
+  color: $color__placeholder;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+textarea:-moz-placeholder {             /* Mozilla Firefox 4 to 18 */
+  color: $color__placeholder;
+  font-size: 16px;
+  font-weight: 400;
+  opacity: 1;
+}
+
+textarea::-moz-placeholder {            /* Mozilla Firefox 19+ */
+  $color: $color__placeholder;
+  font-size: 16px;
+  font-weight: 400;
+  opacity: 1;
+}
+
+textarea:-ms-input-placeholder {        /* Internet Explorer 10-11 */
+  color: $color__placeholder;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+textarea:placeholder-shown {            /* Standard Pseudo-class */
+  color: $color__placeholder;
+  font-size: 16px;
+  font-weight: 400;
+} 
+
 body {
   height: 100%;
   min-height: 100%;


### PR DESCRIPTION
Deprecated use of async caused several warnings while testing

Replaced 
```
import { async, ComponentFixture, TestBed } from '@angular/core/testing';
...
beforeEach(async(() => {
    TestBed.configureTestingModule({
    ...
```
with

```
import { ComponentFixture, TestBed } from '@angular/core/testing';
...
beforeEach(async () => {
    await TestBed.configureTestingModule({
...
```

