### PR TITLE
#172 added simular breadcrumb to each page

### DIFF
--- a/src/app/archive/components/archive-details-page/archive-details-page.component.html
+++ b/src/app/archive/components/archive-details-page/archive-details-page.component.html
@@ -1,7 +1,7 @@
 <div class="archive-details-page standard-content-container-width">
   <section class="top">
     <app-case-details *ngIf="case" [case]="case">
-      <app-breadcrumb class="breadcrumb" [links]="breadcrumbLinks"></app-breadcrumb>
+      <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
     </app-case-details>
   </section>
 

--- a/src/app/archive/components/archive-details-page/archive-details-page.component.ts
+++ b/src/app/archive/components/archive-details-page/archive-details-page.component.ts
@@ -52,7 +52,8 @@ export class ArchiveDetailsPageComponent implements OnInit {
 
   authenticated$ = this.authService.auth$.pipe(map((authState) => authState.isLoggedIn));
 
-  breadcrumbLinks: BreadcrumbLink[] = [{ label: 'Gelöste Fälle', link: '/archive' }];
+  breadcrumbLinks: BreadcrumbLink[] = [{ label: 'Gelöste Fälle', link: '/archive' }, {label: 'Detail'}];
+
   archiveQuestions: any[] = [
     {
       title: 'Was bedeutet das Ergebnis?',

--- a/src/app/archive/components/archive/archive.component.html
+++ b/src/app/archive/components/archive/archive.component.html
@@ -1,7 +1,7 @@
 <div class="archive-page standard-content-container-width">
   <div class="top-section">
     <div class="overview-section">
-      <app-breadcrumb></app-breadcrumb>
+      <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
       <h1>Gelöste Fälle</h1>
       <p>
         Hier siehst du eine Übersicht aller Fälle, deren Bearbeitung abgeschlossen ist.

--- a/src/app/archive/components/archive/archive.component.ts
+++ b/src/app/archive/components/archive/archive.component.ts
@@ -12,6 +12,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ArchiveListFilterComponent } from '../archive-list-filter/archive-list-filter.component';
 import { CaseSort, CaseSortBy } from '../../model/case-sort';
 import { ViewportScroller } from '@angular/common';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-archive',
@@ -64,6 +65,8 @@ export class ArchiveComponent {
   public resultScoreMode = ResultScoreMode.bar;
 
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Gelöste Fälle'}];
 
   archiveListFilterOpened = false;
 

--- a/src/app/core/components/community-guidelines/community-guidelines.component.html
+++ b/src/app/core/components/community-guidelines/community-guidelines.component.html
@@ -1,44 +1,51 @@
 <div class="standard-content-container-width terms-container">
-  <h1>Nutzungsbedingungen</h1>
-  <div>
-    <div>
+  <div class="top-section">
+    <div class="overview-section">
+      <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
       <div>
-        <article>
+        <h1>Nutzungsbedingungen</h1>
+        <div>
           <div>
             <div>
-              <h2>Haftung f&uuml;r Inhalte&nbsp;</h2>
-              <p>Als Diensteanbieter sind wir gem&auml;&szlig; &sect; 7 Abs.1 TMG f&uuml;r eigene Inhalte auf diesen
-                Seiten nach den allgemeinen Gesetzen verantwortlich. Nach &sect;&sect; 8 bis 10 TMG sind wir als
-                Diensteanbieter jedoch nicht verpflichtet, &uuml;bermittelte oder gespeicherte fremde Informationen zu
-                &uuml;berwachen oder nach Umst&auml;nden zu forschen, die auf eine rechtswidrige T&auml;tigkeit
-                hinweisen.&nbsp;</p>
-              <p>Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen
-                Gesetzen
-                bleiben hiervon unber&uuml;hrt. Eine diesbez&uuml;gliche Haftung ist jedoch erst ab dem Zeitpunkt der
-                Kenntnis einer konkreten Rechtsverletzung m&ouml;glich. Bei Bekanntwerden von entsprechenden
-                Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
-              <h2>Haftung f&uuml;r Links&nbsp;</h2>
-              <p>Unser Angebot enth&auml;lt Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss
-                haben. Deshalb k&ouml;nnen wir f&uuml;r diese fremden Inhalte auch keine Gew&auml;hr &uuml;bernehmen.
-                F&uuml;r die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten
-                verantwortlich.</p>
-              <p>Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist ohne konkrete Anhaltspunkte einer
-                Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links
-                umgehend entfernen.&nbsp;</p>
-              <h2>Urheberrecht&nbsp;</h2>
-              <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen
-                Urheberrecht. Die Vervielf&auml;ltigung, Bearbeitung, Verbreitung und jede Art der Verwertung
-                au&szlig;erhalb der Grenzen des Urheberrechtes bed&uuml;rfen der schriftlichen Zustimmung des jeweiligen
-                Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur f&uuml;r den privaten, nicht
-                kommerziellen Gebrauch gestattet.&nbsp;</p>
-              <p>Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte
-                Dritter
-                beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine
-                Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden
-                von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.&nbsp;</p>
+              <article>
+                <div>
+                  <div>
+                    <h2>Haftung f&uuml;r Inhalte&nbsp;</h2>
+                    <p>Als Diensteanbieter sind wir gem&auml;&szlig; &sect; 7 Abs.1 TMG f&uuml;r eigene Inhalte auf diesen
+                      Seiten nach den allgemeinen Gesetzen verantwortlich. Nach &sect;&sect; 8 bis 10 TMG sind wir als
+                      Diensteanbieter jedoch nicht verpflichtet, &uuml;bermittelte oder gespeicherte fremde Informationen zu
+                      &uuml;berwachen oder nach Umst&auml;nden zu forschen, die auf eine rechtswidrige T&auml;tigkeit
+                      hinweisen.&nbsp;</p>
+                    <p>Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen
+                      Gesetzen
+                      bleiben hiervon unber&uuml;hrt. Eine diesbez&uuml;gliche Haftung ist jedoch erst ab dem Zeitpunkt der
+                      Kenntnis einer konkreten Rechtsverletzung m&ouml;glich. Bei Bekanntwerden von entsprechenden
+                      Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
+                    <h2>Haftung f&uuml;r Links&nbsp;</h2>
+                    <p>Unser Angebot enth&auml;lt Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss
+                      haben. Deshalb k&ouml;nnen wir f&uuml;r diese fremden Inhalte auch keine Gew&auml;hr &uuml;bernehmen.
+                      F&uuml;r die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten
+                      verantwortlich.</p>
+                    <p>Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist ohne konkrete Anhaltspunkte einer
+                      Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links
+                      umgehend entfernen.&nbsp;</p>
+                    <h2>Urheberrecht&nbsp;</h2>
+                    <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen
+                      Urheberrecht. Die Vervielf&auml;ltigung, Bearbeitung, Verbreitung und jede Art der Verwertung
+                      au&szlig;erhalb der Grenzen des Urheberrechtes bed&uuml;rfen der schriftlichen Zustimmung des jeweiligen
+                      Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur f&uuml;r den privaten, nicht
+                      kommerziellen Gebrauch gestattet.&nbsp;</p>
+                    <p>Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte
+                      Dritter
+                      beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine
+                      Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden
+                      von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.&nbsp;</p>
+                  </div>
+                </div>
+              </article>
             </div>
           </div>
-        </article>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/core/components/community-guidelines/community-guidelines.component.spec.ts
+++ b/src/app/core/components/community-guidelines/community-guidelines.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CommunityGuidelinesComponent } from './community-guidelines.component';
 import { BreadcrumbModule } from '@shared/breadcrumb/breadcrumb.module';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CommunityGuidelinesComponent', () => {
   let component: CommunityGuidelinesComponent;
@@ -10,7 +11,10 @@ describe('CommunityGuidelinesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ CommunityGuidelinesComponent ],
-      imports: [ BreadcrumbModule ],
+      imports: [
+        BreadcrumbModule,
+        RouterTestingModule.withRoutes([]),
+      ],
     })
     .compileComponents();
   });

--- a/src/app/core/components/community-guidelines/community-guidelines.component.spec.ts
+++ b/src/app/core/components/community-guidelines/community-guidelines.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CommunityGuidelinesComponent } from './community-guidelines.component';
+import { BreadcrumbModule } from '@shared/breadcrumb/breadcrumb.module';
 
 describe('CommunityGuidelinesComponent', () => {
   let component: CommunityGuidelinesComponent;
@@ -8,7 +9,8 @@ describe('CommunityGuidelinesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ CommunityGuidelinesComponent ]
+      declarations: [ CommunityGuidelinesComponent ],
+      imports: [ BreadcrumbModule ],
     })
     .compileComponents();
   });

--- a/src/app/core/components/community-guidelines/community-guidelines.component.ts
+++ b/src/app/core/components/community-guidelines/community-guidelines.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-community-guidelines',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./community-guidelines.component.scss']
 })
 export class CommunityGuidelinesComponent implements OnInit {
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Nutzungsbedingungen'}];
 
   constructor() { }
 

--- a/src/app/core/components/imprint/imprint.component.html
+++ b/src/app/core/components/imprint/imprint.component.html
@@ -1,7 +1,7 @@
 <div class="imprint-page standard-content-container-width">
     <div class="top-section">
       <div class="overview-section">
-        <app-breadcrumb></app-breadcrumb>
+        <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
         <div>
           <h1>Impressum</h1>
           <h3>Angaben gemäß § 5 TMG</h3>                  

--- a/src/app/core/components/imprint/imprint.component.ts
+++ b/src/app/core/components/imprint/imprint.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-imprint',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./imprint.component.scss']
 })
 export class ImprintComponent implements OnInit {
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Impressum'}];
 
   constructor() { }
 

--- a/src/app/core/components/privacy-statement/privacy-statement.component.html
+++ b/src/app/core/components/privacy-statement/privacy-statement.component.html
@@ -1,7 +1,7 @@
 <div class="privacy-page standard-content-container-width">
   <div class="top-section">
     <div class="overview-section">
-      <app-breadcrumb></app-breadcrumb>
+      <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
       <div>
           <h1>Datenschutzerklärung</h1>         
           <section class="privacy-statement-intro">

--- a/src/app/core/components/privacy-statement/privacy-statement.component.ts
+++ b/src/app/core/components/privacy-statement/privacy-statement.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-privacy-statement',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./privacy-statement.component.scss']
 })
 export class PrivacyStatementComponent implements OnInit {
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Datenschutzerklärung'}];
 
   constructor() { }
 

--- a/src/app/faq/components/faq-page/faq-page.component.html
+++ b/src/app/faq/components/faq-page/faq-page.component.html
@@ -1,7 +1,7 @@
 <div class="faq-page standard-content-container-width">
   <div class="top-section">
     <div class="overview-section">
-      <app-breadcrumb class="breadcrumb" [links]="breadcrumbLinks"></app-breadcrumb>
+      <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
       <div>
         <h1>FAQ</h1>
         <p>Hier findest du eine Übersicht über die am häufigsten gestellten Fragen.<br/>

--- a/src/app/faq/components/faq-page/faq-page.component.ts
+++ b/src/app/faq/components/faq-page/faq-page.component.ts
@@ -9,7 +9,7 @@ import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interfa
 })
 export class FaqPageComponent implements OnInit {
 
-  breadcrumbLinks: BreadcrumbLink[] = [{label: 'FAQ', link: '/faq'}];
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'FAQ'}];
 
   constructor() {
   }

--- a/src/app/my-profile/components/my-profile/my-profile.component.html
+++ b/src/app/my-profile/components/my-profile/my-profile.component.html
@@ -1,6 +1,6 @@
 <div class="profile-page" *ngIf="user$ | async as user">
   <section class="top-section standard-content-container-width">
-    <app-breadcrumb></app-breadcrumb>
+    <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
     <div class="overview">
       <div class="overview__user">
         <div class="avatar">{{ user.name[0].toUpperCase() }}</div>

--- a/src/app/my-profile/components/my-profile/my-profile.component.ts
+++ b/src/app/my-profile/components/my-profile/my-profile.component.ts
@@ -5,6 +5,7 @@ import { AuthService } from '@shared/auth/auth-service/auth.service';
 import { DeleteUserDialogComponent } from '../../../core/dialogs/delete-user-dialog/delete-user-dialog.component';
 import { UserService } from '../../../core/services/user/user.service';
 import { Globals } from '@shared/helper/globals/globals';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-my-profile',
@@ -16,6 +17,8 @@ export class MyProfileComponent {
   authState$ = this.authService.auth$;
 
   page = 1;
+
+  breadcrumbLinks: BreadcrumbLink[] = [];
 
   constructor(private userService: UserService, private authService: AuthService, private router: Router, private dialog: MatDialog) {}
 

--- a/src/app/review-item/components/review-page/review-page.component.html
+++ b/src/app/review-item/components/review-page/review-page.component.html
@@ -1,7 +1,7 @@
 <div class="review-page standard-content-container-width" *ngIf="case$ | async as case">
   <section class="top">
     <app-case-details [case]="case" [description]="description">
-      <app-breadcrumb class="breadcrumb" [links]="breadcrumbLinks"></app-breadcrumb>
+      <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
     </app-case-details>
     <app-user-experience-bubble-list [userExperienceBubbles]="userExperienceBubbles"></app-user-experience-bubble-list>
   </section>

--- a/src/app/review-item/components/review-page/review-page.component.ts
+++ b/src/app/review-item/components/review-page/review-page.component.ts
@@ -37,7 +37,7 @@ export class ReviewPageComponent implements OnInit, OnDestroy {
 
   user$ = this.userService.user$;
 
-  breadcrumbLinks: BreadcrumbLink[] = [{ label: 'Fall lösen', link: '/reviews' }];
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Fall lösen'}];
   case: Item;
   isOpenReview: boolean;
   review: Review;

--- a/src/app/review-item/components/review-success-page/review-success-page.component.ts
+++ b/src/app/review-item/components/review-success-page/review-success-page.component.ts
@@ -15,7 +15,7 @@ import { Item } from '../../../model/item';
 export class ReviewSuccessPageComponent {
   user$ = this.userService.user$;
 
-  breadcrumbLinks: BreadcrumbLink[] = [{ label: 'Fall lösen', link: '/reviews' }];
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Fall lösen'}];
 
   case: Item;
 

--- a/src/app/shared/breadcrumb/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/breadcrumb/breadcrumb/breadcrumb.component.html
@@ -2,7 +2,8 @@
   <i class="far fa-home breadcrumb__link" routerLink="/"></i>
   <i class="fal fa-greater-than"></i>
   <ng-container *ngFor="let breadcrumbLink of links; let last = last">
-    <span class="breadcrumb__link" [routerLink]="breadcrumbLink.link">{{ breadcrumbLink.label }}</span>
+    <span class="breadcrumb__link" *ngIf="!last" [routerLink]="breadcrumbLink.link">{{ breadcrumbLink.label }}</span>
     <i class="fal fa-greater-than" *ngIf="!last"></i>
-  </ng-container>  
+    <span *ngIf="last">{{ breadcrumbLink.label }}</span>
+  </ng-container>
 </span>

--- a/src/app/shared/breadcrumb/model/breadcrumb-link.interface.ts
+++ b/src/app/shared/breadcrumb/model/breadcrumb-link.interface.ts
@@ -1,4 +1,4 @@
 export interface BreadcrumbLink {
   label: string;
-  link: string;
+  link?: string;
 }

--- a/src/app/static-pages/about/about.component.html
+++ b/src/app/static-pages/about/about.component.html
@@ -1,6 +1,6 @@
 <div class="background">
   <div class="standard-content-container-width">
-    <app-breadcrumb></app-breadcrumb>
+    <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
     <h1>Über codetekt e.V.</h1>
     <div class="intro">
       <img class="image" src="assets/images/illustrations/undraw_quiz_nlyh.svg" />

--- a/src/app/static-pages/about/about.component.ts
+++ b/src/app/static-pages/about/about.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-about',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./about.component.scss']
 })
 export class AboutComponent implements OnInit {
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Der Verein'}];
 
   constructor() { }
 

--- a/src/app/static-pages/team-page/team-page/team-page.component.html
+++ b/src/app/static-pages/team-page/team-page/team-page.component.html
@@ -1,6 +1,6 @@
 <div class="team-page standard-content-container-width">
     <div class="teampage-container">
-        <app-breadcrumb></app-breadcrumb>
+        <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
         <h1>Wir, das Team</h1>
         <p>codetekt ist ein dezentrales Team, das sich der Herausforderung annimmt, eine Lösung gegen
             unglaubwürdige Nachrichten im Web oder in verschlüsselten Messaging Apps zu entwickeln.</p>

--- a/src/app/static-pages/team-page/team-page/team-page.component.ts
+++ b/src/app/static-pages/team-page/team-page/team-page.component.ts
@@ -4,6 +4,7 @@ import { TagService } from './tag.service';
 import {Member} from 'src/app/model/member';
 import {TagInfo} from 'src/app/model/membertags';
 import { HttpClient } from '@angular/common/http';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 @Component({
   selector: 'app-team-page',
   templateUrl: './team-page.component.html',
@@ -13,6 +14,8 @@ export class TeamPageComponent implements OnInit {
 
   members: Member[] = [];
   tagsInfo: TagInfo[];
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Das Team'}];
 
   constructor(public tagService: TagService, private httpClient: HttpClient) { }
 

--- a/src/app/static-pages/trust-checking/trust-checking-page/trust-checking-page.component.html
+++ b/src/app/static-pages/trust-checking/trust-checking-page/trust-checking-page.component.html
@@ -1,6 +1,6 @@
 <div class="section-background">
     <div class="standard-content-container-width">
-        <app-breadcrumb></app-breadcrumb>
+        <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
 
         <div class="intro">
             <h1>Das codetekt Trust-Checking</h1>

--- a/src/app/static-pages/trust-checking/trust-checking-page/trust-checking-page.component.ts
+++ b/src/app/static-pages/trust-checking/trust-checking-page/trust-checking-page.component.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { TrustCheckingCriterion } from 'src/app/model/trust-checking-criterion';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 @Component({
   selector: 'app-trust-checking-page',
   templateUrl: './trust-checking-page.component.html',
@@ -9,6 +10,8 @@ import { TrustCheckingCriterion } from 'src/app/model/trust-checking-criterion';
 export class TrustCheckingPageComponent implements OnInit {
 
   tcCriteria: TrustCheckingCriterion[] = [];
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Trust-Checking'}];
 
   constructor(private httpclient: HttpClient) { }
 

--- a/src/app/submit-item/components/submit-page/submit-page.component.html
+++ b/src/app/submit-item/components/submit-page/submit-page.component.html
@@ -4,7 +4,7 @@
     <div>
       <div class="top-section standard-content-container-width">
         <div class="overview-section">
-          <app-breadcrumb></app-breadcrumb>
+          <app-breadcrumb [links]="breadcrumbLinks"></app-breadcrumb>
           <h1>Fall einreichen</h1>
           <div>
             <p>

--- a/src/app/submit-item/components/submit-page/submit-page.component.ts
+++ b/src/app/submit-item/components/submit-page/submit-page.component.ts
@@ -9,6 +9,7 @@ import { ItemTypesService } from '../../services/item-types/item-types.service';
 import { SubmitItemService } from '../../services/submit-item.service';
 import { QuestionPrompt } from './../../model/question-prompt.interface';
 import { ViewEncapsulation } from '@angular/core';
+import { BreadcrumbLink } from '@shared/breadcrumb/model/breadcrumb-link.interface';
 
 @Component({
   selector: 'app-submit-page',
@@ -64,6 +65,8 @@ export class SubmitPageComponent {
     policy: false,
     condition: false
   };
+
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Fall einreichen'}];
 
   constructor(
     private submitItemService: SubmitItemService,

--- a/src/app/submit-item/components/submit-success-page/submit-success-page.component.ts
+++ b/src/app/submit-item/components/submit-success-page/submit-success-page.component.ts
@@ -15,7 +15,7 @@ import { Item } from '../../../model/item';
   providers: []
 })
 export class SubmitSuccessPageComponent {
-  breadcrumbLinks: BreadcrumbLink[] = [{ label: 'Fall einreichen', link: '/submit' }];
+  breadcrumbLinks: BreadcrumbLink[] = [{label: 'Fall einreichen'}];
 
   item: Item;
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -70,7 +70,7 @@ textarea:placeholder-shown {            /* Standard Pseudo-class */
   color: $color__placeholder;
   font-size: 16px;
   font-weight: 400;
-} 
+}
 
 body {
   height: 100%;
@@ -126,7 +126,7 @@ body {
 .carousel .carousel-arrows .carousel-arrow {
   background-color: unset !important;
   box-shadow: unset !important;
-  top: 42% !important;  
+  top: 42% !important;
   width: 18px !important;
   background-size: 60px !important;
 }
@@ -446,20 +446,6 @@ header.header {
 
 .mat-radio-button:not(.mat-radio-disabled).cdk-program-focused .mat-radio-persistent-ripple {
   opacity: 0 !important;
-}
-
-.breadcrumb {
-  font-size: 14px;
-  color: $color__old-paragraph;
-
-  &__link {
-    cursor: pointer;
-  }
-
-  span,
-  i ~ i {
-    margin-left: 4px;
-  }
 }
 
 .mono-font {


### PR DESCRIPTION
Ich hab mir jetzt Breadcrumb Namen ausgedacht, manche sind identisch zur H1 und manche etwas anders.

Da die Profile Seite aktuell ja die Homepage mit "/" ist, hab ich dort den Breadcrumb dort komplett leer gelassen.

@Th3da 
Ich hab auf der Nutzungsbedingungseite (community-guidelines.component.html) noch den Breadcrumb und die DIV-Tags top-section und overview-section hinzugefügt. Es sieht aber immer noch anders aus als auf den anderen Seiten. Machst du das dann im Rahmen deines Styling Tickets.

