### PR TITLE
Clear timeout in component destructor to avoid memory leaks

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, HostListener } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { UserService } from './core/services/user/user.service';
 import { User } from './core/model/user';
@@ -13,7 +13,8 @@ import { filter } from 'rxjs/operators';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
+  static timeOutID: any;
   public user: User;
 
   constructor(
@@ -32,6 +33,11 @@ export class AppComponent {
     this.handleAnchorScrolling();
   }
 
+  @HostListener('unloaded')
+  public ngOnDestroy(): void {
+    clearTimeout(AppComponent.timeOutID);
+  }
+
   /**
    * Fixes Angular anchor scrolling behavior
    */
@@ -39,7 +45,7 @@ export class AppComponent {
     this.viewportScroller.setOffset([0, 80]);
     this.router.events.pipe(filter((e) => e instanceof Scroll)).subscribe((e: Scroll) => {
       if (e.anchor) {
-        setTimeout(() => {
+        AppComponent.timeOutID = setTimeout(() => {
           this.viewportScroller.scrollToAnchor(e.anchor);
         });
       } else if (e.position) {


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of DetektivKollektiv website, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found an uncleared timer causing the memory to leak (screenshots below).

[before]
<img width="1277" alt="before timer fix Screen Shot 2023-02-06 at 8 25 06 PM" src="https://user-images.githubusercontent.com/56495631/216967280-d6f807ae-d4a7-4c66-8125-e36dbded4a84.png">


Hence we added the fix by clearing the timeout on component unload, and you can see the heap size and # of leaks reducing noticeably:
 <br />

<img width="1267" alt="Screen Shot 2023-02-06 at 8 32 14 PM" src="https://user-images.githubusercontent.com/56495631/216967329-13e3ebe9-7a6f-4ba8-b647-a7126256ebd5.png">


Note 1. Host listener is used to ensure that ngOnDestroy is called not only when the class destroy, but also when the page refreshes, tab or browser closes or the user navigates away from the page[1]

Note 2. Static property is used to avoid losing the context of the correct ‘this’ in case any nesting changes are made to the enclosing function in future.

We executed the test suite after the fixes and it successfully passed 65 of 65 total. We also ran the lint on the changes to ensure the added code complies with the lining standard of the project.

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[angular_ui_scenario_memlab.txt](https://github.com/DetektivKollektiv/angular-ui/files/10662745/angular_ui_scenario_memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.

References:
[1] https://wesleygrimes.com/angular/2019/03/29/making-upgrades-to-angular-ngondestroy.html


